### PR TITLE
Bring ZeroMQ in line with the use of ZMQ topics in MISP 2.4.75

### DIFF
--- a/scripts/push_published_to_taxii.py
+++ b/scripts/push_published_to_taxii.py
@@ -45,13 +45,20 @@ cli.set_auth(username = config["taxii"]["auth"]["username"],
 
 while True:
     # Wait for something to come in on the ZMQ socket
-    message = socket.recv().decode("utf-8")[10:]
-
+    message = socket.recv().decode("utf-8")
     log.info("Recieved a message!")
+    topic = message.split(' ', 1)[0]
+
+    if topic != 'misp_json':
+      log.info("Ignoring " + topic + "...")
+      continue
+
+    # Process the JSON payload
     log.debug("Processing...")
+    payload = message[len(topic)+1:]
 
     # Load the message JSON
-    msg = json.loads(message)
+    msg = json.loads(payload)
 
     log.debug(msg)
 


### PR DESCRIPTION
`push_published_to_taxii.py` was failing in all sorts of ways because MISP now uses ZMQ topics. This patchs makes it work again.