### PR TITLE
Fix cronjob example to execute every sixth hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ crontab -e
 This will open your crontab. Paste in
 
 ```cron
-* */6 * * * <the output of that echo command you just ran>
+0 */6 * * * <the output of that echo command you just ran>
 ```
 
 This will run the polling script every 6 hours to keep things all synced up.


### PR DESCRIPTION
Example as written executes the command at every minute past the sixth hour. Replacing the * with 0 in the beginning will cause this to run at minute 0 at every sixth hour.