### PR TITLE
Fix for "no attribute '_json_full'" error

### DIFF
--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -74,7 +74,7 @@ def post_stix(manager, content_block, collection_ids, service_id):
     # But I don't wanna read docs
     if (len(package.attributes) > 0):
         log.info("Uploading event to MISP with attributes %s", [x.value for x in package.attributes])
-        MISP.add_event(package._json_full())
+        MISP.add_event(package)
     else:
         log.info("No attributes, not bothering.")
 


### PR DESCRIPTION
Fix for "'MISPEvent' object has no attribute '_json_full'" error.
Now events are created in MISP as desired.