### PR TITLE
Fix for the "Data truncated for column..." warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,28 @@ This will run the polling script every 6 hours to keep things all synced up.
 
 ## Troubleshooting
 
+### Data truncated for column...
+
+```python 
+Warning: (1265, "Data truncated for column 'original_message' at row 1")
+
+Warning: (1265, "Data truncated for column 'content' at row 1")
+```
+
+If you encounter the error above, this means you tried to push a STIX file bigger than 65,535 bytes. To fix it run the following commands.
+```bash
+mysql -u [database user] -p
+# Enter Database password
+
+mysql> use taxiipersist;
+
+mysql> alter table `inbox_messages` modify `original_message` LONGTEXT;
+
+mysql> alter table `content_blocks` modify `content` LONGTEXT;
+
+mysql> exit;
+```
+
 ### Specified key was too long
 
 ```python 


### PR DESCRIPTION
Adding a STIX file bigger than 65,535 bytes, the mysql max size for text type is reached.
So the file is truncated and not importable in MISP via the OpenTAXII hook or other way to push STIX data in your internal INBOX.

Here is my pragmatic solution.