### PR TITLE
Bringing up-to-date with recent PyMISP and Optional Deduplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.yaml
 __pycache__
 build
 dist
+hooks_2.py

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ config.yaml
 __pycache__
 build
 dist
-hooks_2.py

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 build
 dist
 src
+vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.yaml
 __pycache__
 build
 dist
+src

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -29,6 +29,7 @@ zmq:
 misp:
     url: "http://localhost"
     api: KEY
+    dedup: true
 
 taxii:
     auth:

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -30,6 +30,10 @@ misp:
     url: "http://localhost"
     api: KEY
     dedup: true
+    collections:
+      - my_collection
+      - my_collection2
+    publish: false
 
 taxii:
     auth:

--- a/config/local-server.default.yaml
+++ b/config/local-server.default.yaml
@@ -1,0 +1,12 @@
+host: localhost
+port: 9000
+discovery_path: /services/discovery
+inbox_path: /services/inbox
+use_https: False
+taxii_version: '1.1'
+headers:
+auth:
+  username: test
+  password: test
+collections:
+  - collection

--- a/config/remote-servers.default.yaml
+++ b/config/remote-servers.default.yaml
@@ -1,0 +1,18 @@
+- name: 'default'
+  host: localhost
+  port: 9000
+  discovery_path:
+  use_https: False
+  taxii_version: '1.1'
+  headers:
+  auth:
+    username:
+    password:
+    cacert_path:
+    cert_file:
+    key_file:
+    key_password:
+    jwt_auth_url:
+    verify_ssl: True
+  collections:
+    - collection

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -119,7 +119,7 @@ def post_stix(manager, content_block, collection_ids, service_id):
 
     try:
         package = pymisp.tools.stix.load_stix(StringIO(block))
-    except:
+    except Exception:
         log.error('Could not load stix into MISP format; exiting.')
         return 0
     log.debug("STIX loaded succesfully.")

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -158,7 +158,7 @@ def post_stix(manager, content_block, collection_ids, service_id):
         try:
             if MISP:
                 event = MISP.add_event(package)
-        except ConnectionError, NameError:
+        except ConnectionError:
             log.error("Cannot push to MISP; please ensure that MISP is up and running at {}. Skipping MISP upload.".format(CONFIG['misp']['url']))
         if (
             CONFIG["misp"]["publish"] == True or

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -67,12 +67,22 @@ def post_stix(manager, content_block, collection_ids, service_id):
     for attrib in values:
         log.info("Checking for existence of %s", attrib)
         search = MISP.search("attributes", values=str(attrib))
-        if search["response"]["Attribute"] != []:
-            # This means we have it!
-            log.info("%s is a duplicate, we'll ignore it.", attrib)
-            package.attributes.pop([x.value for x in package.attributes].index(attrib))
+        if 'response' in search:
+            if search["response"]["Attribute"] != []:
+                # This means we have it!
+                log.info("%s is a duplicate, we'll ignore it.", attrib)
+                package.attributes.pop([x.value for x in package.attributes].index(attrib))
+            else:
+                log.info("%s is unique, we'll keep it", attrib)
+        elif 'Attribute' in search:
+            if search["Attribute"] != []:
+                # This means we have it!
+                log.info("%s is a duplicate, we'll ignore it.", attrib)
+                package.attributes.pop([x.value for x in package.attributes].index(attrib))
+            else:
+                log.info("%s is unique, we'll keep it", attrib)
         else:
-            log.info("%s is unique, we'll keep it", attrib)
+            log.error("Something went wrong with search, and it doesn't have an 'attribute' or a 'response' key: {}".format(search.keys()))
 
     # Push the event to MISP
     # TODO: There's probably a proper method to do this rather than json_full

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -30,7 +30,7 @@ def env_config_helper(env_name):
 
 def yaml_config_helper(config_name, CONFIG):
     if config_name in CONFIG["misp"]:
-        if not CONFIG["misp"][config_name]:
+        if not CONFIG["misp"][config_name] and CONFIG["misp"][config_name] != False:
             CONFIG["misp"][config_name] = "UNKNOWN"
     else:
         CONFIG["misp"][config_name] = "UNKNOWN"

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -146,6 +146,8 @@ def post_stix(manager, content_block, collection_ids, service_id):
         ):
             log.info("Publishing event to MISP with ID {}".format(event.get('uuid')))
             MISP.publish(event)
+        else:
+            log.info("Skipping MISP event publishing")
     else:
         log.info("No attributes, not bothering.")
 

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -9,6 +9,7 @@ import pymisp
 import tempfile
 import logging
 from pyaml import yaml
+from yaml import Loader
 from io import StringIO
 
 log = logging.getLogger("__main__")
@@ -20,7 +21,7 @@ from opentaxii.signals import (
 ## CONFIG
 if "OPENTAXII_CONFIG" in os.environ:
     print("Using config from {}".format(os.environ["OPENTAXII_CONFIG"]))
-    CONFIG =  yaml.load(open(os.environ["OPENTAXII_CONFIG"], "r"))
+    CONFIG =  yaml.load(open(os.environ["OPENTAXII_CONFIG"], "r"), Loader=Loader)
 else:
     print("Trying to use env variables...")
     if "MISP_URL" in os.environ:

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -113,8 +113,12 @@ def post_stix(manager, content_block, collection_ids, service_id):
     block = content_block.content
     if isinstance(block, bytes):
         block = block.decode()
- 
-    package = pymisp.tools.stix.load_stix(StringIO(block))
+
+    try:
+        package = pymisp.tools.stix.load_stix(StringIO(block))
+    except:
+        log.error('Could not load stix into MISP format; exiting.')
+        return 0
     log.info("STIX loaded succesfully.")
     values = [x.value for x in package.attributes]
     log.info("Extracted %s", values)
@@ -130,6 +134,8 @@ def post_stix(manager, content_block, collection_ids, service_id):
             search = ''
             if MISP:
                 search = MISP.search("attributes", values=str(attrib))
+            else:
+                return 0
             if 'response' in search:
                 if search["response"]["Attribute"] != []:
                     # This means we have it!

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -78,7 +78,7 @@ def post_stix(manager, content_block, collection_ids, service_id):
     if CONFIG["misp"]["collections"] != "UNKNOWN" or CONFIG["misp"]["collections"] == False:
         log.info("Using collections")
         should_send_to_misp = False
-        collection_names = [collection.name for collection in manager.get_collections(service_id)]
+        collection_names = [collection.name for collection in manager.get_collections(service_id) if collection.id in collection_ids]
         for collection in CONFIG["misp"]["collections"]:
             if collection in collection_names or collection in collection_ids:
                 log.info("Collection specified matches push collection: {}".format(collection))

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -22,6 +22,8 @@ from opentaxii.signals import (
 if "OPENTAXII_CONFIG" in os.environ:
     print("Using config from {}".format(os.environ["OPENTAXII_CONFIG"]))
     CONFIG =  yaml.load(open(os.environ["OPENTAXII_CONFIG"], "r"), Loader=Loader)
+    if "dedup" not in CONFIG["misp"]:
+        CONFIG["misp"]["dedup"] = "UNKNOWN"
 else:
     print("Trying to use env variables...")
     if "MISP_URL" in os.environ:
@@ -70,7 +72,11 @@ def post_stix(manager, content_block, collection_ids, service_id):
     log.info("STIX loaded succesfully.")
     values = [x.value for x in package.attributes]
     log.info("Extracted %s", values)
-    if CONFIG['MISP_DEDUP'] == "true" or CONFIG['MISP_DEDUP'] == "True" or CONFIG['MISP_DEDUP'] == "TRUE" or CONFIG['MISP_DEDUP'] == "UNKNOWN":
+    if (
+        CONFIG["misp"]["dedup"] == True or 
+        CONFIG["misp"]["dedup"] == "True" or 
+        CONFIG["misp"]["dedup"] == "UNKNOWN"
+    ):
         for attrib in values:
             log.info("Checking for existence of %s", attrib)
             search = MISP.search("attributes", values=str(attrib))

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -15,10 +15,12 @@ from requests.exceptions import ConnectionError
 
 logging_level = logging.INFO
 log = logging.getLogger("__main__")
+handler = logging.StreamHandler()
 log.setLevel(logging_level)
 handler.setLevel(logging_level)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 handler.setFormatter(formatter)
+log.addHandler(handler)
 
 
 from opentaxii.signals import (

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -76,11 +76,14 @@ def post_stix(manager, content_block, collection_ids, service_id):
 
     # make sure collections, if specified are supposed to be sent to 
     if CONFIG["misp"]["collections"] != "UNKNOWN" or CONFIG["misp"]["collections"] == False:
+        log.info("Using collections")
         should_send_to_misp = False
         collection_names = [collection.name for collection in manager.get_collections(service_id)]
         for collection in CONFIG["misp"]["collections"]:
             if collection in collection_names or collection in collection_ids:
+                log.info("Collection specified matches push collection: {}".format(collection))
                 should_send_to_misp = True
+                break
         if should_send_to_misp == False:
             log.info('''No collections match misp.collections; aborting MISP extraction.
     Collection ids whitelisted: {}

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -131,6 +131,8 @@ def post_stix(manager, content_block, collection_ids, service_id):
                     log.info("%s is unique, we'll keep it", attrib)
             else:
                 log.error("Something went wrong with search, and it doesn't have an 'attribute' or a 'response' key: {}".format(search.keys()))
+    else:
+        log.info("Skipping deduplication")
 
     # Push the event to MISP
     # TODO: There's probably a proper method to do this rather than json_full
@@ -139,10 +141,10 @@ def post_stix(manager, content_block, collection_ids, service_id):
         log.info("Uploading event to MISP with attributes %s", [x.value for x in package.attributes])
         event = MISP.add_event(package)
         if (
-            CONFIG["misp"]["publish"] or
+            CONFIG["misp"]["publish"] == True or
             CONFIG["misp"]["publish"] == "True"
         ):
-            log.info("Publishing event to MISP with ID {}".format(event['id']))
+            log.info("Publishing event to MISP with ID {}".format(event.get('uuid')))
             MISP.publish(event)
     else:
         log.info("No attributes, not bothering.")

--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -77,15 +77,18 @@ def post_stix(manager, content_block, collection_ids, service_id):
     # make sure collections, if specified are supposed to be sent to 
     if CONFIG["misp"]["collections"] != "UNKNOWN" or CONFIG["misp"]["collections"] == False:
         should_send_to_misp = False
+        collection_names = [collection.name for collection in manager.get_collections(service_id)]
         for collection in CONFIG["misp"]["collections"]:
-            if collection in collection_ids:
+            if collection in collection_names or collection in collection_ids:
                 should_send_to_misp = True
         if should_send_to_misp == False:
             log.info('''No collections match misp.collections; aborting MISP extraction.
     Collection ids whitelisted: {}
-    Collection ids sent to: {}'''.format(
+    Collection ids sent to: {}
+    Collection names sent to: {}'''.format(
                 CONFIG["misp"]["collections"],
-                collection_ids
+                collection_ids,
+                collection_names
             ))
             return None
 

--- a/scripts/push_published_to_taxii.py
+++ b/scripts/push_published_to_taxii.py
@@ -4,6 +4,7 @@ import sys
 import json
 import pymisp
 from pyaml import yaml
+from yaml import Loader
 from cabby import create_client
 from misp_stix_converter.converters import lint_roller
 import logging
@@ -20,7 +21,7 @@ log.setLevel(logging.DEBUG)
 log.info("Starting...")
 # Try to load in config
 if "OPENTAXII_CONFIG" in os.environ:
-    config = yaml.load(open(os.environ["OPENTAXII_CONFIG"], "r"))
+    config = yaml.load(open(os.environ["OPENTAXII_CONFIG"], "r"), Loader=Loader)
 else:
     print("OPENTAXII CONFIG NOT EXPORTED")
     sys.exit()

--- a/scripts/run-taxii-poll.py
+++ b/scripts/run-taxii-poll.py
@@ -2,6 +2,7 @@
 
 from cabby import create_client
 from pyaml import yaml
+from yaml import Loader
 import pytz
 import argparse
 import os
@@ -51,14 +52,14 @@ config_file = "{}/remote-servers.yml".format(
 
 log.debug("Opening config file %s", config_file)
 with open(config_file, "r") as f:
-    config = yaml.load(f.read())
+    config = yaml.load(f.read(), Loader=Loader)
 log.debug("Config read %s", config)
 
 # Read in the local server configuration
 local_config = "{}/local-server.yml".format(os.path.expanduser(args.configdir))
 log.debug("Reading local server config")
 with open(local_config, "r") as f:
-    local_config = yaml.load(f.read())
+    local_config = yaml.load(f.read(), Loader=Loader)
 
 # Attempt to make contact with the local server
 log.info("Connecting to local server...")


### PR DESCRIPTION
# Summary
This PR brings `MISP-Taxii-Server` up-to-date with the most recent `PyMISP`. This should fix #80. We can also make deduplication optional so that if the MISP server is substantially large, the `search` function doesn't hog resources. This should fix #81. 

## Purpose
The purpose of this PR is to keep this repo backwards compatible with the most recent `PyMISP` and bring it up-to-date with the most recent version. 

## Solution Implementation
The way we do this is by checking to make sure that the `response` key exists in the `search` dictionary returned by `pymisp.search()`. In the most recent version, the `response` key does not exist, and the `Attribute` key is moved up one level to the top level of the `search` dictionary. If neither of these keys exist in the top level, we log the issue and move on to the next attribute.

Next we fix the hanging issue by making deduplication optional, while still maintaining backwards compatibility with old `MISP-Taxii-Server` configs. We can do this by adding in a new argument to the config or env variables: `misp.dedup` and `MISP_DEDUP` respectively. If this config is not found, we continue deduplicating like the original program would. If it is found, and is not `True`, we skip the deduplication loop and move straight on to uploading the package to MISP.

## Additional Features
There's also additional features I'd like to add in this PR:
- Ability to constrain pushing to MISP to select collections by name or ID
- Ability to publish added MISP events automatically

## Changes
- `hooks.py`
  - Added definition, initialization, and checking for dedup config
  - Added checking for correct key in `search` dictionary
  - Added MISP publish config checking and feature
  - Added MISP collections config checking and feature
- `config/config.default.yaml`
  - Added new keys to `misp` hook config
    - `dedup`: `bool`
    - `collections`: `list<str>`
    - `publish`: `bool`