### PR TITLE
Attribute search in hooks.py is stalling, fixed it to use the right API

### DIFF
--- a/misp_taxii_hooks/hooks.py
+++ b/misp_taxii_hooks/hooks.py
@@ -65,8 +65,8 @@ def post_stix(manager, content_block, collection_ids, service_id):
     log.info("Extracted %s", values)
     for attrib in values:
         log.info("Checking for existence of %s", attrib)
-        search = MISP.search("attributes", values=str(attrib))
-        if search["response"]["Attribute"] != []:
+        search = MISP.search(controller="attributes", value=str(attrib))
+        if search["Attribute"] != []:
             # This means we have it!
             log.info("%s is a duplicate, we'll ignore it.", attrib)
             package.attributes.pop([x.value for x in package.attributes].index(attrib))


### PR DESCRIPTION
`search = MISP.search("attributes", values=str(attrib))` stalls, latest pyMISP api doc doesn't have a `values` attribute for the search() function, set it to `value` , explicilty set the first parameter as `controller` as well. The response json does not have the parent `response` object, changed that as well. 

TAXII sync is now working for me with this change.